### PR TITLE
Save access token to Keychain Access.app

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Download and double-click.
 
 Register CircleCI Token.
 
-- save to `token` file in workflow's data folder
+- `apikey` saved in your `Keychain Access.app`
 
 ```
 circleci token <XXXX>


### PR DESCRIPTION
More secure compared to the file :)

<img width="762" alt="keychain-access" src="https://user-images.githubusercontent.com/1402528/33304088-1eb4fe30-d44a-11e7-812c-92f1644f7818.png">

- Thanks for the URL.
  - [Go で Datadog の Alfred Workflow を作った](https://blog.tsub.me/post/create-alfred-workflow/)
